### PR TITLE
IO submodule

### DIFF
--- a/pyriksdagen/args.py
+++ b/pyriksdagen/args.py
@@ -214,6 +214,34 @@ def interpellation_args(args):
     return args
 
 
+def volg_parser(parser):
+    """
+    Take an argparse ArgumentParser object and populate standard arguments for working with riksdagen volume G.
+
+    Args:
+        parser: parser
+
+    Returns:
+        parser
+    """
+    parser = populate_common_arguments(parser)
+    # leaving the interpellations-specific function in place, in case we need volg-specific args
+    return parser
+
+
+def volg_args(args):
+    """
+    Takes an argparse namespace object for working with riksdagen volume G and imputes standard stuff
+
+    Args:
+        args: args
+
+    Returns:
+        args
+    """
+    args = common_args(args)
+    # leaving the interpellations-specific function in place, in case we need volG-specific actions
+    return args
 
 
 def fetch_parser(doctype, docstring=None):
@@ -231,6 +259,7 @@ def fetch_parser(doctype, docstring=None):
             "records": record_parser,
             "motions": motion_parser,
             "interpellations": interpellation_parser,
+            "volg": volg_parser,
         }
     parser = argparse.ArgumentParser(description=docstring)
     parser.add_argument("--doctype", default=doctype, help=argparse.SUPPRESS)
@@ -253,6 +282,7 @@ def impute_args(args):
             "records": record_args,
             "motions": motion_args,
             "interpellations": interpellation_args,
+            "volg": volg_args
         }
     return D[args.doctype](args)
 

--- a/pyriksdagen/args.py
+++ b/pyriksdagen/args.py
@@ -288,6 +288,28 @@ def impute_args(args):
 
 
 
+def fetch_doctype_parser(raw_args, docstring=None):
+    def _no_doctype_arg_error(err, corpora):
+        errs = {
+                1: "You didn't set any first argument.",
+                2: "You passed an invalid doctype."
+            }
+        raise ValueError(f"You have to pass the document type as the first argument of this script ({' '.join(['--'+k+',' for k in corpora.keys()])})\n{errs[err]}")
+
+    corpora = {
+            "records": record_parser,
+            "motions": motion_parser,
+            "interpellations": interpellation_parser,
+            "volg": volg_parser,
+        }
+    if not raw_args[1]:
+        _no_doctype_arg_error(1, corpora)
+    if raw_args[1][2:] in corpora:
+        return fetch_parser(raw_args[1][2:], docstring=__doc__), raw_args[2:]
+
+    else:
+        _no_doctype_arg_error(2, corpora)
+
 
 # test
 if __name__ == '__main__':

--- a/pyriksdagen/io.py
+++ b/pyriksdagen/io.py
@@ -20,8 +20,8 @@ def parse_tei(_path, get_ns=True) -> tuple:
     root = etree.parse(_path, parser).getroot()
     if get_ns:
         ns = {
-                "tei_ns": "{http://www.w3.org/XML/1998/namespace}",
-                "xml_ns": "{http://www.tei-c.org/ns/1.0}",
+                "xml_ns": "{http://www.w3.org/XML/1998/namespace}",
+                "tei_ns": "{http://www.tei-c.org/ns/1.0}",
             }
         return root, ns
     else:
@@ -157,7 +157,7 @@ def write_tei(root, dest_path, ns="{http://www.tei-c.org/ns/1.0}", custom_order=
         else:
             # assume tei header doesn't mix child elements and text
             if has_text and elem.text.strip() != '' and len(elem) == 0:
-                parts[-1] += f"{elem.text.strip()}</{elem.tag.replace(ns, '')}>"
+                parts[-1] += f"{' '.join([escape(_.strip()) for _ in elem.text.split() if _.strip() != ''])}</{elem.tag.replace(ns, '')}>"
             else:
                 for child in elem:
                     parts.append(_serialize(child, padding=padding+2, custom_order=custom_order, is_body=False))

--- a/pyriksdagen/io.py
+++ b/pyriksdagen/io.py
@@ -1,8 +1,20 @@
-
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Utilities for reading and writing TEI files
+"""
 from collections import OrderedDict
 from lxml import etree
 from xml.sax.saxutils import escape
 
+
+XML_NS = "{http://www.w3.org/XML/1998/namespace}"
+TEI_NS = "{http://www.tei-c.org/ns/1.0}"
+
+
+def fetch_ns():
+    return {"tei_ns": TEI_NS,
+            "xml_ns": XML_NS}
 
 
 def parse_tei(_path, get_ns=True) -> tuple:
@@ -19,11 +31,7 @@ def parse_tei(_path, get_ns=True) -> tuple:
     parser = etree.XMLParser(remove_blank_text=True)
     root = etree.parse(_path, parser).getroot()
     if get_ns:
-        ns = {
-                "xml_ns": "{http://www.w3.org/XML/1998/namespace}",
-                "tei_ns": "{http://www.tei-c.org/ns/1.0}",
-            }
-        return root, ns
+        return root, fetch_ns()
     else:
         return root
 

--- a/pyriksdagen/io.py
+++ b/pyriksdagen/io.py
@@ -1,0 +1,198 @@
+
+from collections import OrderedDict
+from lxml import etree
+from xml.sax.saxutils import escape
+
+
+
+def parse_tei(_path, get_ns=True) -> tuple:
+    """
+    Parse a protocol, return root element (and namespace defnitions).
+
+    Args:
+        _path (str): path to tei-xml doc
+        get_ns (bool): also return namespace dict
+
+    Returns:
+        tuple/etree._Element: root and an optional namespace dict
+    """
+    parser = etree.XMLParser(remove_blank_text=True)
+    root = etree.parse(_path, parser).getroot()
+    if get_ns:
+        ns = {
+                "tei_ns": "{http://www.w3.org/XML/1998/namespace}",
+                "xml_ns": "{http://www.tei-c.org/ns/1.0}",
+            }
+        return root, ns
+    else:
+        return root
+
+
+def write_tei(root, dest_path, ns="{http://www.tei-c.org/ns/1.0}", custom_order=None) -> None:
+    """
+    Write a TEI corpus document to disk.
+
+    Args:
+        elem (etree._Element): tei root element
+        dest_path (str): protocol path
+        custom_order (list): custom order for leading attributes in element
+    """
+    def _sort_attrs(attrib, custom_order=["xml:id",
+                                          "who",
+                                          "type",
+                                          "subtype",
+                                          "prev",
+                                          "next",]):
+        """
+        Sort an element's attributes, first by the custom order, then any remaining alphabetically
+
+        Args:
+            attrib: Etree Element's attributes
+            custom_prder (list): list of attributes in the order we want
+
+        Returns:
+            d (ordered dict): ordered element attributes
+        """
+        d = OrderedDict()
+        attrs = dict(attrib)
+        #print(attrs)
+        def key_label(k):
+            if k == "{http://www.w3.org/XML/1998/namespace}id":
+                return "xml:id"
+            return k
+
+        # Reverse-map Clark notation for xml:id
+        fixed_attrs = {}
+        for k, v in attrs.items():
+            fixed_key = "xml:id" if k == "{http://www.w3.org/XML/1998/namespace}id" else k
+            fixed_attrs[fixed_key] = v
+
+        d = OrderedDict()
+        for key in custom_order:
+            if key in fixed_attrs:
+                d[key] = fixed_attrs.pop(key)
+        for key, val in dict(sorted(fixed_attrs.items())).items():
+            d[key] = fixed_attrs[key]
+        #print("  ~~", d)
+        return d
+
+
+    def _format_paragraph(paragraph, spaces, max_line_width=60):
+        """
+        format paragraphss with indentation and fixed max-width for each line
+
+        Args:
+            paragraph (str): text of element to be formatted
+            spaces (int): the number of spaces to indent text by
+            max_line_width (int): maximum width of the text column in characters
+
+        Returns:
+            s (str): formatted text of element
+        """
+        s = spaces
+        words = [_.strip() for _ in paragraph.replace("\n", " ").strip().split() if _.strip() != '']
+        row = ""
+        for word in words:
+            word = escape(word)
+            if len(row) > max_line_width:
+                s += row.strip() + "\n" + spaces
+                row = word
+            else:
+                row += " " + word
+
+        if len(row.strip()) > 0:
+            s += row.strip()
+        if s.strip() == "":
+            return None
+        return s
+
+
+    def _serialize(elem, indent=' ', padding=2, custom_order=None, is_body=True):
+        """
+        Custom XML serializer for TEI/text that works recursively on the
+            element tree, while respecting indentation, line breaks and custom attribute order
+
+        Args:
+            elem (etree Element): The root element to serialize from. typically this is TEI/text
+            indent (str): character to use for indentation. default is a single whitespace character
+            padding (int): number of indent character's to use for each level of indentation. default=2
+            custom_order (list): custom order for leading attributes in element
+
+        Returns:
+            Serilaized string of elem
+
+        """
+        ind = indent * padding
+        child_ind = indent * (padding + 2)
+
+        # Build sorted attribute string
+        if custom_order is not None:
+            sorted_attrs = _sort_attrs(elem.attrib, custom_order=custom_order)
+        else:
+            sorted_attrs = _sort_attrs(elem.attrib)
+        attr_str = " ".join(f'{k}="{v}"' for k, v in sorted_attrs.items())
+        # Check for self-closing condition
+        has_text = bool(elem.text and elem.text.strip())
+        has_children = len(elem) > 0
+
+        if not has_text and not has_children:
+            # Self-closing tag
+            tag = elem.tag.replace(ns, '')
+            return f"{ind}<{tag}" + (f" {attr_str}" if attr_str else "") + "/>"
+
+        # Normal open tag
+        start_tag = f"{ind}<{elem.tag.replace(ns, '')}" + (f" {attr_str}" if attr_str else "") + ">"
+        parts = [start_tag]
+
+        # Format .text
+        if is_body:
+            if has_text:
+                parts.append(_format_paragraph(elem.text.strip(), child_ind))
+            for child in elem:
+                parts.append(_serialize(child, padding=padding+2, custom_order=custom_order))
+                # Format .tail
+                if child.tail and child.tail.strip():
+                    parts.append(_format_paragraph(child.tail.strip(), child_ind))
+            parts.append(ind + f"</{elem.tag.replace(ns, '')}>")
+        else:
+            # assume tei header doesn't mix child elements and text
+            if has_text and elem.text.strip() != '' and len(elem) == 0:
+                parts[-1] += f"{elem.text.strip()}</{elem.tag.replace(ns, '')}>"
+            else:
+                for child in elem:
+                    parts.append(_serialize(child, padding=padding+2, custom_order=custom_order, is_body=False))
+                parts.append(ind + f"</{elem.tag.replace(ns, '')}>")
+        return "\n".join([_ for _ in parts if _.strip() != ''])
+
+
+    try:
+        header = root.find(f".//teiHeader")
+        assert header != None
+    except:
+        header = root.find(f".//{ns}teiHeader")
+        try:
+            assert header != None
+        except:
+            raise ValueError("header can't be None")
+
+    try:
+        body = root.find(f".//text")
+        assert body != None
+    except:
+        body = root.find(f".//{ns}text")
+        try:
+            assert body != None
+        except:
+            raise ValueError("body can't be None")
+
+    body = _serialize(body, custom_order=custom_order)
+    header = _serialize(header, padding=2, custom_order=custom_order, is_body=False)
+    xml = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        f'<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="{dest_path.split("/")[-1][:-4]}">',
+        header,
+        body,
+        '</TEI>\n'
+    ]
+    with open(dest_path, "w+") as f:
+        f.write('\n'.join(xml))

--- a/pyriksdagen/utils.py
+++ b/pyriksdagen/utils.py
@@ -170,7 +170,8 @@ def corpus_iterator(document_type, corpus_root=None, start=None, end=None):
         "motions":"motions",
         "mot": "motions",
         "prot": "records",
-        "records": "records"
+        "records": "records",
+        "volg": "volg",
     }
     if document_type not in doctypes:
         raise ValueError(f"{document_type} not valid")
@@ -324,6 +325,7 @@ def get_data_location(partition):
     d["metadata"] = os.environ.get("METADATA_PATH", "data")
     d["metadata_db"] = os.environ.get("METADATA_DB", "data")               # path to csv or pkl of compiled Corpus()
     d["interpellations"] = os.environ.get("INTERPELLATIONS_PATH", "data")
+    d["volg"] = os.environ.get("VOLUMEG_PATH", "data")
     assert partition in d, f"Provide valid partition of the dataset ({list(d.keys())})"
     return d[partition]
 

--- a/pyriksdagen/utils.py
+++ b/pyriksdagen/utils.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from lxml import etree
 from pathlib import Path
 from pyparlaclarin.refine import format_texts
+from pyriksdagen.io import parse_tei as parse_tei_new
+from pyriksdagen.io import write_tei as write_tei_new
 from tqdm import tqdm
 from trainerlog import get_logger
 import base58
@@ -191,24 +193,6 @@ def corpus_iterator(document_type, corpus_root=None, start=None, end=None):
             yield str(doc.relative_to("."))
 
 
-def protocol_iterators(corpus_root=None, document_type=None, start=None, end=None):
-    """
-    Deprecate - Use corpus_iterator() instead.
-    Returns an iterator of protocol paths in a corpus.
-
-    Args:
-        corpus_root (str): path to the corpus root. If env variable RECORDS_PATH exists, uses that as a default
-        document_type (str): type of document (prot, mot, etc.). If None, fetches all types
-        start (int): start year
-        end (int): end year
-
-    Returns:
-        iterator of the protocols as relative paths to current location
-    """
-    warnings.warn("protocol_iterators is replaced by corpus_iterator() and may be removed in future versions -- use that instead.", DeprecationWarning, stacklevel=2)
-    return corpus_iterator("prot", corpus_root=corpus_root, start=start, end=end)
-
-
 def parse_date(s):
     """
     Parse datetimes with special error handling
@@ -325,72 +309,6 @@ def get_doc_dates(protocol):
             match_error = True
         dates.append(when_attrib)
     return match_error, dates
-
-
-def write_tei(elem, dest_path) -> None:
-    """
-    Write a corpus document to disk.
-
-    Args:
-        elem (etree._Element): tei root element
-        dest_path (str): protocol path
-    """
-    elem = format_texts(elem, padding=10)
-    b = etree.tostring(
-        elem,
-        pretty_print=True,
-        encoding="utf-8",
-        xml_declaration=True
-    )
-    with open(dest_path, "wb") as f:
-        f.write(b)
-
-
-def write_protocol(prot_elem, prot_path) -> None:
-    """
-    Write the protocol to a file.
-
-    Args:
-        prot_elem (etree._Element): protocol root element
-        prot_path (str): protocol path
-    """
-    warnings.warn("write_protocol is replaced by write_tei() and may be removed in future versions -- use that instead.", DeprecationWarning, stacklevel=2)
-    write_tei(prot_elem, prot_path)
-
-
-def parse_tei(_path, get_ns=True) -> tuple:
-    """
-    Parse a protocol, return root element (and namespace defnitions).
-
-    Args:
-        _path (str): path to tei-xml doc
-        get_ns (bool): also return namespace dict
-
-    Returns:
-        tuple/etree._Element: root and an optional namespace dict
-    """
-    parser = etree.XMLParser(remove_blank_text=True)
-    root = etree.parse(_path, parser).getroot()
-    if get_ns:
-        ns = fetch_ns()
-        return root, ns
-    else:
-        return root
-
-
-def parse_protocol(protocol_path, get_ns=False) -> tuple:
-    """
-    Parse a protocol, return root element (and namespace defnitions).
-
-    Args:
-        protocol_path (str): protocol path
-        get_ns (bool): also return namespace dict
-
-    Returns:
-        tuple/etree._Element: root and an optional namespace dict
-    """
-    warnings.warn("parse_protocol is replaced by parse_tei() and may be removed in future versions -- use that instead.", DeprecationWarning, stacklevel=2)
-    return parse_tei(protocol_path, get_ns=get_ns)
 
 
 def get_data_location(partition):
@@ -546,3 +464,81 @@ def pathize_protocol_id(protocol_id):
         if os.path.exists(path_):
             return path_
     raise FileNotFoundError(f"Can't find {path_}")
+
+
+
+##########################
+    """
+#   Deprecated functions #
+    """
+##########################
+def parse_tei(_path, get_ns=True) -> tuple:
+    """
+    Parse a protocol, return root element (and namespace defnitions).
+
+    Args:
+        _path (str): path to tei-xml doc
+        get_ns (bool): also return namespace dict
+
+    Returns:
+        tuple/etree._Element: root and an optional namespace dict
+    """
+    warnings.warn("parse_tei() has been moved to the pyriksdagen.io submodule and will be removed from pyriksdagen.utils in the next major release -- use parse_tei() from pyriksdagen.io instead.", DeprecationWarning, stacklevel=2)
+    return parse_tei_new(_path, get_ns=get_ns)
+
+
+def parse_protocol(protocol_path, get_ns=False) -> tuple:
+    """
+    Parse a protocol, return root element (and namespace defnitions).
+
+    Args:
+        protocol_path (str): protocol path
+        get_ns (bool): also return namespace dict
+
+    Returns:
+        tuple/etree._Element: root and an optional namespace dict
+    """
+    warnings.warn("parse_protocol is replaced by parse_tei() and may be removed in future versions -- use that instead.", DeprecationWarning, stacklevel=2)
+    return parse_tei(protocol_path, get_ns=get_ns)
+
+
+def protocol_iterators(corpus_root=None, document_type=None, start=None, end=None):
+    """
+    Deprecate - Use corpus_iterator() instead.
+    Returns an iterator of protocol paths in a corpus.
+
+    Args:
+        corpus_root (str): path to the corpus root. If env variable RECORDS_PATH exists, uses that as a default
+        document_type (str): type of document (prot, mot, etc.). If None, fetches all types
+        start (int): start year
+        end (int): end year
+
+    Returns:
+        iterator of the protocols as relative paths to current location
+    """
+    warnings.warn("protocol_iterators is replaced by corpus_iterator() and may be removed in future versions -- use that instead.", DeprecationWarning, stacklevel=2)
+    return corpus_iterator("prot", corpus_root=corpus_root, start=start, end=end)
+
+
+def write_tei(root, dest_path, ns="{http://www.tei-c.org/ns/1.0}") -> None:
+    """
+    Write a corpus document to disk.
+
+    Args:
+        elem (etree._Element): tei root element
+        dest_path (str): protocol path
+    """
+    warnings.warn("write_tei() as been moved to the pyriksdagen.io submodule and removed from pyriksdagen.utils in the next major release -- use write_tei() from pyriksdagen.io instead.", DeprecationWarning, stacklevel=2)
+    write_tei_new(root, dest_path)
+
+
+def write_protocol(prot_elem, prot_path) -> None:
+    """
+    Write the protocol to a file.
+
+    Args:
+        prot_elem (etree._Element): protocol root element
+        prot_path (str): protocol path
+    """
+    warnings.warn("write_protocol is replaced by write_tei() and may be removed in future versions -- use that instead.", DeprecationWarning, stacklevel=2)
+    write_tei(prot_elem, prot_path)

--- a/pyriksdagen/utils.py
+++ b/pyriksdagen/utils.py
@@ -10,6 +10,11 @@ from pathlib import Path
 from pyparlaclarin.refine import format_texts
 from pyriksdagen.io import parse_tei as parse_tei_new
 from pyriksdagen.io import write_tei as write_tei_new
+from pyriksdagen.io import (
+    fetch_ns,
+    TEI_NS,
+    XML_NS,
+)
 from tqdm import tqdm
 from trainerlog import get_logger
 import base58
@@ -25,13 +30,7 @@ import zipfile
 
 
 LOGGER = get_logger("pyriksdagen")
-XML_NS = "{http://www.w3.org/XML/1998/namespace}"
-TEI_NS = "{http://www.tei-c.org/ns/1.0}"
 
-
-def fetch_ns():
-    return {"tei_ns": TEI_NS,
-            "xml_ns": XML_NS}
 
 
 def elem_iter(root, ns="{http://www.tei-c.org/ns/1.0}"):


### PR DESCRIPTION
utils.py is yuuge, so parsing and writing TEI moved to its own submodule. This in combination with a write function that handles parlaclarin and vanilla TEI.

new custom serializer:
- doesn't rely on a predefined set of tags
- handles variable depth of indentation
- orders attributes
- formats paragraphs in-house (no pyparlaclarin)

Data sample in action in https://github.com/swerik-project/riksdagen-motions/pull/52