### PR TITLE
cast data type

### DIFF
--- a/pyriksdagen/metadata.py
+++ b/pyriksdagen/metadata.py
@@ -58,7 +58,8 @@ def impute_member_dates(db, metadata_folder):
         elif pd.isna(row['start']) and pd.isna(row['end']):
             return row
         else:
-            riksmote = pd.read_csv(f"{metadata_folder}/riksdag-year.csv")
+            riksmote = pd.read_csv(f"{metadata_folder}/riksdag-year.csv",
+                                   dtype={"start": "string", "end": "string"})
             if pd.isna(row['start']) or row['start'] == 'nan':
                 try:
                     py = riksmote.loc[


### PR DESCRIPTION
mp test in the records repo fails because of data type mismatches. I don't have this problem locally, but I think (hope) the fix here sorts it out.